### PR TITLE
Fix: Update flutter_map parameters

### DIFF
--- a/lib/app/central/modules/dashboard/cyclone_details_page.dart
+++ b/lib/app/central/modules/dashboard/cyclone_details_page.dart
@@ -144,8 +144,8 @@ class CycloneDetailsPage extends StatelessWidget {
                         borderRadius: BorderRadius.circular(8.0),
                         child: FlutterMap(
                           options: MapOptions(
-                            center: LatLng(loc.latitude, loc.longitude),
-                            zoom: 8.0, // Zoom level for a more focused view
+                            initialCenter: LatLng(loc.latitude, loc.longitude),
+                            initialZoom: 8.0, // Zoom level for a more focused view
                           ),
                           children: [
                             TileLayer(
@@ -158,7 +158,7 @@ class CycloneDetailsPage extends StatelessWidget {
                                   width: 80.0,
                                   height: 80.0,
                                   point: LatLng(loc.latitude, loc.longitude),
-                                  builder: (ctx) => const Icon(
+                                  child: const Icon(
                                     Icons.cyclone,
                                     color: Colors.orangeAccent,
                                     size: 40.0,

--- a/lib/app/central/modules/dashboard/dashboard_page.dart
+++ b/lib/app/central/modules/dashboard/dashboard_page.dart
@@ -177,7 +177,7 @@ class _DashboardViewState extends State<DashboardView> {
           width: 80.0,
           height: 80.0,
           point: point,
-          builder: (ctx) => GestureDetector(
+          child: GestureDetector(
             onTap: () {
               final eventData = event.predictionData;
               if (event.type == DisasterType.cyclone && eventData is CyclonePrediction) {

--- a/lib/app/central/modules/dashboard/flood_details_page.dart
+++ b/lib/app/central/modules/dashboard/flood_details_page.dart
@@ -133,8 +133,8 @@ class FloodDetailsPage extends StatelessWidget {
                         borderRadius: BorderRadius.circular(8.0),
                         child: FlutterMap(
                           options: MapOptions(
-                            center: LatLng(floodPrediction.lat, floodPrediction.lon),
-                            zoom: 9.0, // Zoom level
+                            initialCenter: LatLng(floodPrediction.lat, floodPrediction.lon),
+                            initialZoom: 9.0, // Zoom level
                           ),
                           children: [
                             TileLayer(
@@ -147,7 +147,7 @@ class FloodDetailsPage extends StatelessWidget {
                                   width: 80.0,
                                   height: 80.0,
                                   point: LatLng(floodPrediction.lat, floodPrediction.lon),
-                                  builder: (ctx) => Icon(
+                                  child: Icon(
                                     Icons.water_drop,
                                     color: _getRiskColor(floodPrediction.floodRisk),
                                     size: 40.0,


### PR DESCRIPTION
Resolves issues related to flutter_map API changes:
- Changed Marker's `builder` parameter to `child`.
- Changed MapOptions' `center` parameter to `initialCenter`.
- Changed MapOptions' `zoom` parameter to `initialZoom`.
- Ensured FlutterMap uses `children` instead of `layers`.

These changes were applied to:
- cyclone_details_page.dart
- dashboard_page.dart
- flood_details_page.dart